### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/api/v3/RestLog.php
+++ b/api/v3/RestLog.php
@@ -17,7 +17,7 @@ function _civicrm_api3_rest_log_create_spec(&$spec) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_rest_log_create($params) {
   return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
@@ -28,7 +28,7 @@ function civicrm_api3_rest_log_create($params) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_rest_log_delete($params) {
   return _civicrm_api3_basic_delete(_civicrm_api3_get_BAO(__FUNCTION__), $params);
@@ -39,7 +39,7 @@ function civicrm_api3_rest_log_delete($params) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_rest_log_get($params) {
   return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);

--- a/api/v3/RestLog/Getuniquevalues.php
+++ b/api/v3/RestLog/Getuniquevalues.php
@@ -19,7 +19,7 @@ function _civicrm_api3_rest_log_Getuniquevalues_spec(&$spec) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_rest_log_Getuniquevalues($params) {
   if ($params['field'] == 'calling_contact') {


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.